### PR TITLE
Use uv to manage FastAPI dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,8 @@
+[project]
+name = "fastapi-server"
+version = "0.1.0"
+description = "Add your description here"
+requires-python = ">=3.11"
+dependencies = [
+    "fastapi"
+]


### PR DESCRIPTION
## Summary
- Replace requirements file with `pyproject.toml` using uv
- Declare FastAPI dependency to install the latest release via uv

## Testing
- `python -m py_compile main.py`
- `pytest -q`
- `uv lock` *(fails: Failed to fetch `https://pypi.org/simple/fastapi/`)*

------
https://chatgpt.com/codex/tasks/task_e_68b9466032188322a1ffc0da1ce9adcb